### PR TITLE
missing calls of reset functions in ListMultibucket and Multivocab

### DIFF
--- a/parser/structs/buckets/list_multibucket.py
+++ b/parser/structs/buckets/list_multibucket.py
@@ -56,6 +56,8 @@ class ListMultibucket(BaseMultibucket, list):
     self._indices = [[]]
     self._tokens = [[]]
     self._str2idx = {'': 0}
+    for bucket in self:
+      bucket.reset()
     return
   
   #=============================================================

--- a/parser/structs/vocabs/multivocabs.py
+++ b/parser/structs/vocabs/multivocabs.py
@@ -102,6 +102,10 @@ class Multivocab(BaseVocab, list):
       status = (vocab._loaded or vocab.count(train_conllus) if hasattr(vocab, 'count') else True) and status
     return status
   
+  def reset(self):
+    for vocab in self:
+      vocab.reset()
+    return
   #=============================================================
   def get_input_tensor(self, reuse=True):
     """"""


### PR DESCRIPTION
Added override of reset() function in Multivocab class, now it calls the reset() for each vocab object in it.
Added calls of reset() function for every bucket in ListMultibucket class

When I was doing some experiments with parsing one sentence at a time, I noticed that one of multivocabs was saving data even after I called the reset() function. There are 2 little fixes, in case someone will try to do something simmilar.